### PR TITLE
レビューをたのみます

### DIFF
--- a/cogs/addssl.py
+++ b/cogs/addssl.py
@@ -1,5 +1,4 @@
 import gspread
-import json
 #ServiceAccountCredentials：Googleの各サービスへアクセスできるservice変数を生成。
 from oauth2client.service_account import ServiceAccountCredentials
 import os
@@ -7,25 +6,33 @@ from discord.ext import commands
 from typing import Any
 import requests
 from bs4 import BeautifulSoup
+import re
+import discord
+from datetime import datetime, timedelta, timezone
 
 
-class SSLadd(commands.Cog):
+class SSLAdd(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
     @commands.command()
     async def addssl(self, ctx, addurl):
 
-        #ちゃんとURLかチェック！
-        if f"{addurl}".startswith('http'):
+        #最初にaddssl引数がURLかを判断し、URL出ない場合はエラーを返す
+        if not f"{addurl}".startswith('http'):
+            await ctx.send(f"URLを指定してください！")
 
-            #URLからHPのタイトルをとってくる
+        #httpから始まる文字列の場合は処理をすすめる
+        else:
             url = f"{addurl}"
             session = requests.Session()
             session.trust_env = False
             response = requests.get(f"{addurl}")
             soup = BeautifulSoup(response.content, 'html.parser')
-            title = soup.find('title').text
+            #タイトルをゲットし、前後の空白や改行をすべて取る（ナオトインティライミのHPは前後に空白が16個ずつも入っていた！ふざけるな！）
+            title = soup.find('title').text.strip()
+            #その後中盤に改行やTABが入っている場合は取る
+            plain_title = re.sub('\n|\t|', '', title)
 
             #環境変数を設定
             TAKO_GSP_JSON = os.environ["TAKOHACHI_JSON"]
@@ -39,27 +46,50 @@ class SSLadd(commands.Cog):
             addssl_json_keyfile = 'addssl_client_secrets.json'
             credentials = ServiceAccountCredentials.from_json_keyfile_name(addssl_json_keyfile, scope)
 
-
-            #json_keyfile = 'client_secrets.json'
-            #credentials = ServiceAccountCredentials.from_json_keyfile_name(TAKO_GSP_JSON, scope)
-
             #OAuth2の資格情報を使用してGoogle APIにログインします。
             gc = gspread.authorize(credentials)
-
 
             #共有設定したスプレッドシートのシート1を開く
             worksheet = gc.open_by_key(SSLADD_GSP_KEY).sheet1
 
-            # A列とB列にappend。Aはとりあえず空欄。後々はURLからタイトルとってきていれたい
-            export_value = [title, url]
-            worksheet.append_row(export_value)
+            #登録のURLの末尾に/が入っている場合はそれを削除したURL(完全一致判定のため)
+            #not_slash_url = addurl.rstrip('/')
 
-            #自分の最初のコマンドに絵文字リアクション
-            message = ctx.message
-            await message.add_reaction('👍')
+            #//以降の文字列を抽出(便宜的にこれをドメインとする)
+            target = '//'
+            idx = addurl.find(target)
+            domain = addurl[idx+len(target):].rstrip('/')
 
-        else:
-            await ctx.send(f"URLを指定してください！")
+            #ワークシートのデータが入っている行数ゲットする
+            row = worksheet.row_count
+
+            #C列の便宜的ドメインをリストでゲットする
+            domain_lists = worksheet.get(f'C3:C{row}')
+
+            #今回登録したURLの便宜的ドメインが登録されているC列のドメインリストにないかチェック。すでに登録されていた場合はエラーを返す
+            for l in domain_lists:
+                if domain in l:
+                    await ctx.send('すでに登録されています！')
+                    break
+
+                else:
+                    #新規登録と判断できたらgspに書き込みを行う
+                    # A, B, C列にappend
+                    export_value = [plain_title, addurl, domain]
+                    worksheet.append_row(export_value)
+
+                    #自分の最初のコマンドに絵文字リアクション
+                    message = ctx.message
+                    await message.add_reaction('✅')
+
+                    #その後レスポンスメッセージ
+                    embed = discord.Embed()
+                    JST = timezone(timedelta(hours=+9), "JST")
+                    embed.timestamp = datetime.now(JST)
+                    embed.color = discord.Color.green()
+                    embed.description = f"**「{plain_title}」** を監視いたします。\n\n[SSL Checker](https://ssl-checker.vercel.app/) | [SSLC Database](https://docs.google.com/spreadsheets/d/1c25pvMyjQ89OBCvB9whCQQLM_BPXKyY7umsj5wmpP2k/edit?usp=sharing)"
+                    await ctx.send(embed=embed)
+                    break
 
 def setup(bot):
-    bot.add_cog(SSLadd(bot))
+    bot.add_cog(SSLAdd(bot))


### PR DESCRIPTION
まだバグってるのでレビューのみお願いします。

70行目からの「C列の便宜的ドメインリスト」に今回登録するURLの便宜的ドメインが存在する場合は  
「すでに登録されています！」  
を返して、elseの場合は、gspに書き込む処理を行いbreakで行けた！  

と思ったんだけど、この「すでに登録されています」判定がうまく動いていないっぽい。  
すでに登録されているURLを`!!addssl`してもまた登録されてしまうようです。

domain_lists はprintしてみたらたしかに
[['aaa'], ['bbb'], ['ccc'], ['ddd'], ...]の形でC列全てきっちりリストで取れているようでした。  

また、試しにcolabで

```python
lists = [['test'], ['unko'], ['manko']]
word = 'test'

for l in lists:
  if word in l:
    print('ok!')
    break
  
  else:
    print('ng!')
    break
```
とやった場合は思ったとおりにwordの値に応じて、ok!とng!がprintされました。  

なんでや！！

身体が痛い。
