### PR TITLE
push for tkm review

### DIFF
--- a/cogs/dic.py
+++ b/cogs/dic.py
@@ -1,0 +1,73 @@
+import os
+import discord
+from discord.ext import commands
+from datetime import datetime, timedelta, timezone
+from typing import Any
+import gspread
+#ServiceAccountCredentials：Googleの各サービスへアクセスできるservice変数を生成。
+from oauth2client.service_account import ServiceAccountCredentials
+from discord.ext import commands
+import os
+from typing import Any
+from datetime import datetime, timedelta, timezone
+
+
+class Dictionary(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def dic(self, ctx,  *, words = 'default'):
+
+        #引数がない場合はreturn
+        if words == 'default':
+            embed = discord.Embed()
+            embed.title = f"ピスタチオゲーム部ディクショナリー"
+            JST = timezone(timedelta(hours=+9), "JST")
+            embed.timestamp = datetime.now(JST)
+            embed.color = discord.Color.dark_gold()
+            embed.description = f'`!!dic <word>`で意味を返すします。\n[check & edit the dictionary](https://docs.google.com/spreadsheets/d/15QCsHsmtZAs1FtiCplLmybU80WyxWw4C7G6ESf2b9f4/edit?usp=sharing)'
+            await ctx.send(embed=embed)
+            return
+
+        else:
+            #環境変数を設定
+            DIC_KEY = os.environ["DIC_KEY"]
+
+            #2つのAPIを記述しないとリフレッシュトークンを3600秒毎に発行し続けなければならないです！
+            scope = ['https://spreadsheets.google.com/feeds','https://www.googleapis.com/auth/drive']
+
+            #認証情報設定
+            #ダウンロードしたjsonファイル名をクレデンシャル変数に設定（秘密鍵、Pythonファイルから読み込みしやすい位置に置く）
+            addssl_json_keyfile = 'addssl_client_secrets.json'
+            credentials = ServiceAccountCredentials.from_json_keyfile_name(addssl_json_keyfile, scope)
+
+            #OAuth2の資格情報を使用してGoogle APIにログインします。
+            gc = gspread.authorize(credentials)
+
+            #共有設定したスプレッドシートのシート1を開く
+            worksheet = gc.open_by_key(DIC_KEY).sheet1
+
+            #ワークシートのデータが入っている行数ゲットする
+            row = worksheet.row_count
+
+            #A列のauthor_nameをリストで取得する
+            word_list = worksheet.get(f'A2:C{row}')
+
+            cell = worksheet.find(str(words))
+
+            dic_value = worksheet.cell(cell.row, 3).value
+            dic_hiragana = worksheet.cell(cell.row, 2).value
+
+            embed = discord.Embed()
+            embed.title = f"{words}: {dic_hiragana}"
+            JST = timezone(timedelta(hours=+9), "JST")
+            embed.timestamp = datetime.now(JST)
+            embed.color = discord.Color.purple()
+            embed.description = f'{dic_value}\n\n[check & edit the dictionary](https://docs.google.com/spreadsheets/d/15QCsHsmtZAs1FtiCplLmybU80WyxWw4C7G6ESf2b9f4/edit?usp=sharing)'
+            await ctx.send(embed=embed)
+            return
+
+
+def setup(bot):
+    bot.add_cog(Dictionary(bot))


### PR DESCRIPTION
### レビューのための捨てPR

データベースはみんなが編集できるように下記
https://docs.google.com/spreadsheets/d/15QCsHsmtZAs1FtiCplLmybU80WyxWw4C7G6ESf2b9f4/edit?usp=sharing

### やりたかったこと
- `!!dic <ワード>` で意味などを返す
- `!!dic` で決まりのembedを返す

#### 質問1
引数を省略する方法を調べてみたら、引数のデフォルト値を設定する方法がいいのかなとおもったのでこうした。  
他に一般的な方法はあるでしょうか？

#### 質問2
基本的には問題なく動いているんだけど、  
ctrl + cでbotを止めたときに下記のエラーが出る。どういう意味なんだろう。なにかループしているのかな？  
思い通りに動いて入るけどどこかコードによろしくないところがあるのだろうと思う。

エラー 

```
$ python lantest.py
Yeah!_bot_is_on_ready
Exception ignored in: <function _ProactorBasePipeTransport.__del__ at 0x00000173F07B78B0>
Traceback (most recent call last):
  File "C:\Users\xxxx\AppData\Local\Programs\Python\Python39\lib\asyncio\proactor_events.py", line 116, in __del__
    self.close()
  File "C:\Users\xxxx\AppData\Local\Programs\Python\Python39\lib\asyncio\proactor_events.py", line 108, in close
    self._loop.call_soon(self._call_connection_lost, None)
  File "C:\Users\xxxx\AppData\Local\Programs\Python\Python39\lib\asyncio\base_events.py", line 746, in call_soon
    self._check_closed()
  File "C:\Users\xxxx\AppData\Local\Programs\Python\Python39\lib\asyncio\base_events.py", line 510, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
Exception ignored in: <function _ProactorBasePipeTransport.__del__ at 0x00000173F07B78B0>
Traceback (most recent call last):
  File "C:\Users\xxxx\AppData\Local\Programs\Python\Python39\lib\asyncio\proactor_events.py", line 116, in __del__
  File "C:\Users\xxxx\AppData\Local\Programs\Python\Python39\lib\asyncio\proactor_events.py", line 108, in close
  File "C:\Users\xxxx\AppData\Local\Programs\Python\Python39\lib\asyncio\base_events.py", line 746, in call_soon
  File "C:\Users\xxxx\AppData\Local\Programs\Python\Python39\lib\asyncio\base_events.py", line 510, in _check_closed
RuntimeError: Event loop is closed
(.venv) 
```