### PR TITLE
🚮delete: mimeType

### DIFF
--- a/cogs/save_image.py
+++ b/cogs/save_image.py
@@ -85,7 +85,7 @@ class SavaImage(commands.Cog):
         folder_id = os.environ["DRIVE_FOLDER_ID"]
 
         f = drive.CreateFile(
-            {'title': upload_filename, 'mimeType': 'image/jpeg', 'parents': [{'kind': 'drive#fileLink', 'id': folder_id}]})
+            {'title': upload_filename, 'parents': [{'kind': 'drive#fileLink', 'id': folder_id}]})
         f.SetContentFile(filename)
         f.Upload()
 


### PR DESCRIPTION
#68  save_image.pyで画像以外の動画なども画像と判定されてアップロードされる問題について

mimeTypeの指定を削除したら自動判定するんじゃね？と思って消してみたらビンゴっぽい。

一応ローカルでは動いた。

🙏🙏🙏

