### PR TITLE
BUG FIX autodelete.py

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
       - .env
     volumes:
       - ./data/:/data/
+      - ./logs/:/logs/

--- a/src/cogs/autodelete.py
+++ b/src/cogs/autodelete.py
@@ -11,7 +11,7 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
     handlers=[
         TimedRotatingFileHandler(
-            "logs/autodelete-log-{:%Y-%m-%d}.log".format(datetime.now()),
+            "/logs/autodelete-log-{:%Y-%m-%d}.log".format(datetime.now()),
             when="D",
             interval=1,
             backupCount=7


### PR DESCRIPTION
さっきのautodelete.pyのloggingですが、

Dockerコンテナで動作確認をするのを忘れてて、コンテナ内ではBotが起動していなかった。。

```
discord.ext.commands.errors.ExtensionFailed: Extension 'cogs.autodelete'
raised an error: FileNotFoundError:
[Errno 2] No such file or directory: '/app/logs/autodelete-log-2023-01-26.log'
```

とりあえず一旦時間かけたくないのでこうした。

これだと一応ぼBotは動いて logs/ に.logファイルも出力されるんだけど中身は空っぽで、

ログの内容はdocker logs に表示される 👼 なにこれー
