### PR TITLE
🐳Dockerfileとcomposeをより良い感じに

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --only main
 
-FROM python:3.11-alpine
+FROM python:3.11-slim
 
 # ローカルマシン(日本) のときは効果あるかも
 # RUN sed -i 's@archive.ubuntu.com@ftp.jaist.ac.jp/pub/Linux@g' /etc/apt/sources.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
-ARG PYTHON_ENV=python:3.11-slim
+FROM python:3.11-slim as build
 
+RUN python -m pip install --upgrade pip && \
+    pip install poetry && \
+    poetry config virtualenvs.in-project true && \
+    rm -rf /root/.cache/pypoetry
 
-FROM $PYTHON_ENV as build
-
-RUN pip install poetry && poetry config virtualenvs.in-project true
-
-RUN mkdir -p /app
 WORKDIR /app
 
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --only main
 
-
-FROM $PYTHON_ENV as prod
+FROM python:3.11-alpine
 
 # ローカルマシン(日本) のときは効果あるかも
 # RUN sed -i 's@archive.ubuntu.com@ftp.jaist.ac.jp/pub/Linux@g' /etc/apt/sources.list
@@ -26,6 +24,5 @@ COPY --from=build /app/.venv /app/.venv
 COPY src /app
 WORKDIR /app
 
-ENTRYPOINT ["./.venv/bin/python"]
-CMD ["main.py"]
-
+ENTRYPOINT ["/app/.venv/bin/python", "main.py"]
+CMD []

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,8 @@
-version: "3"
 services:
-  python-service:
+  bot:
     restart: always
     build: .
     container_name: "takohachi-bot"
-    tty: true
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
Docker関連をよりスリムに、いい感じにしてみた。

学んだことをすぐ実践します。

イメージサイズが250MBから180MBになった。
おそらく最小では。

一応ローカルで何度もコンテナ立ち上げてBotが動くかは確認した。

## Dockerfile

- [x] ARGをやめた (こっちのほうが俺がわかりやすかったので！スマン)
- [ ] ~~prodの方のステージのベースイメージを思い切ってalpineにした。~~
  - ~~Pythonはベースイメージをalpineにするとクソ遅くなるとの報告が多く、おすすめできないらしいが、それはあくまでビルドが遅くなるらしい。prodで使う分には遅くなった印象がないからいったんこれで様子見。~~
- [x] pip自体のアップデートを入れた。
- [x] `/root/.cache/pypoetry` にできるキャッシュの削除を入れた
  - これはマルチステージビルドなのであんんまり意味なさそう
- [x] `WORKDIR /app` の上にあった `RUN mkdir -p /app` を削除した。WORKDIRで作られるっぽい
- [x] ENTRYPOINTとCMDの記述を変えた。


## docker-compose.yml

なるべく[Compose file specification](https://docs.docker.com/compose/compose-file/)に準拠した compose v2の記述をしてみた。

- [x] compose v2のオススメに沿って、ファイル名をcompose.yamlに変更した。
  - `docker-compose.yml`は後方互換性のためにのこしているだけで、2つのファイルがある場合は `compose.yaml` or `compose.yml` が優先されるとのこと
- [x] これまで先頭に書いていた `version` はv2では[飾りでしかなく不要](https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element) とのことなので削除した。
- [x] service名をなんとなく `bot` に変えた。
- [x] 対話は今回のケースでは不要なので、`tty:true` を削除した。

## 参考

- [Composeファイルでのversion指定は意味なし \- Jaybanuan's Blog](https://redj.hatenablog.com/entry/2022/09/19/220110)