### PR TITLE
🔨fix keyerror handling

### DIFF
--- a/src/cogs/vl_rank_task.py
+++ b/src/cogs/vl_rank_task.py
@@ -66,7 +66,7 @@ class RankTasks(commands.Cog):
                 try:
                         current_season_data = data['data']['by_season'][cogs.valorant_api.current_season]
                 except KeyError:
-                    win_loses = "Unrated"
+                    win_loses = "Unranked"
 
                 final_rank_patched = current_season_data.get('final_rank_patched', "Unrated")
 

--- a/src/cogs/vl_rank_task.py
+++ b/src/cogs/vl_rank_task.py
@@ -21,7 +21,7 @@ class RankTasks(commands.Cog):
 
     @tasks.loop(seconds=600.0)
     async def printer(self):
-        channel = self.bot.get_channel(int("893528538190344192"))
+        channel = self.bot.get_channel(int("924924594706583562"))
 
         # タイムゾーンの生成
         JST = timezone(timedelta(hours=+9), "JST")

--- a/src/cogs/vl_rank_task.py
+++ b/src/cogs/vl_rank_task.py
@@ -32,7 +32,7 @@ class RankTasks(commands.Cog):
         this_hour = today.hour
         this_minute = today.minute
 
-        if this_hour == 11:# and 0 <= this_minute <= 9:
+        if this_hour == 7 and 0 <= this_minute <= 9:
 
             DB_DIRECTORY = "/data/takohachi.db"
 

--- a/src/cogs/vl_rank_task.py
+++ b/src/cogs/vl_rank_task.py
@@ -62,9 +62,25 @@ class RankTasks(commands.Cog):
                 elo = data['data']['current_data']['elo']
                 name = data['data']['name']
                 tag = data['data']['tag']
-                wins = data['data']['by_season'][cogs.valorant_api.current_season]['wins']
-                number_of_games = data['data']['by_season'][cogs.valorant_api.current_season]['number_of_games']
-                loses = number_of_games - wins
+
+                try:
+                    final_rank_patched = data['data']['by_season'][cogs.valorant_api.current_season]['final_rank_patched']
+                except KeyError:
+                    final_rank_patched = "Unrated"
+
+                if final_rank_patched == "Unrated":
+                    win_loses = "Unranked"
+                else:
+                    try:
+                        wins = data['data']['by_season'][cogs.valorant_api.current_season]['wins']
+                    except KeyError:
+                        wins = 0
+                    try:
+                        number_of_games = data['data']['by_season'][cogs.valorant_api.current_season]['number_of_games']
+                    except KeyError:
+                        number_of_games = 0
+                    loses = number_of_games - wins
+                    win_loses = f"{wins}W/{loses}L"
 
                 # 昨日と今日のeloの差分を取得
                 todays_elo = elo - yesterday_elo
@@ -81,7 +97,7 @@ class RankTasks(commands.Cog):
                     plusminus = "±"
 
                 # フォーマットに合わせて整形
-                result_string = f"{emoji} `{name} #{tag}`\n- {currenttierpatched} (+{ranking_in_tier})\n- 前日比: {plusminus}{todays_elo}\n- {wins}W/{loses}L\n\n"
+                result_string = f"{emoji} `{name} #{tag}`\n- {currenttierpatched} (+{ranking_in_tier})\n- 前日比: {plusminus}{todays_elo}\n- {win_loses}\n\n"
 
                 # DBの情報を今日の取得内容で更新
                 cur.execute("UPDATE val_puuids SET name=?, tag=?, yesterday_elo=? WHERE puuid=?", (name, tag, elo, puuid))

--- a/src/cogs/vl_rank_task.py
+++ b/src/cogs/vl_rank_task.py
@@ -21,7 +21,7 @@ class RankTasks(commands.Cog):
 
     @tasks.loop(seconds=600.0)
     async def printer(self):
-        channel = self.bot.get_channel(int("924924594706583562"))
+        channel = self.bot.get_channel(int("893528538190344192"))
 
         # タイムゾーンの生成
         JST = timezone(timedelta(hours=+9), "JST")
@@ -32,7 +32,7 @@ class RankTasks(commands.Cog):
         this_hour = today.hour
         this_minute = today.minute
 
-        if this_hour == 7 and 0 <= this_minute <= 9:
+        if this_hour == 11:# and 0 <= this_minute <= 9:
 
             DB_DIRECTORY = "/data/takohachi.db"
 
@@ -64,21 +64,17 @@ class RankTasks(commands.Cog):
                 tag = data['data']['tag']
 
                 try:
-                    final_rank_patched = data['data']['by_season'][cogs.valorant_api.current_season]['final_rank_patched']
+                        current_season_data = data['data']['by_season'][cogs.valorant_api.current_season]
                 except KeyError:
-                    final_rank_patched = "Unrated"
+                    win_loses = "Unrated"
+
+                final_rank_patched = current_season_data.get('final_rank_patched', "Unrated")
 
                 if final_rank_patched == "Unrated":
                     win_loses = "Unranked"
                 else:
-                    try:
-                        wins = data['data']['by_season'][cogs.valorant_api.current_season]['wins']
-                    except KeyError:
-                        wins = 0
-                    try:
-                        number_of_games = data['data']['by_season'][cogs.valorant_api.current_season]['number_of_games']
-                    except KeyError:
-                        number_of_games = 0
+                    wins: int = current_season_data.get('wins', 0)
+                    number_of_games = current_season_data.get('number_of_games', 0)
                     loses = number_of_games - wins
                     win_loses = f"{wins}W/{loses}L"
 


### PR DESCRIPTION
新エピソードの始まりは最初の5戦は振り分け戦となり、"unranked" の状態のため、keyerrorが発生することがわかったので、そのためのハンドリングです。

- 1試合もやってない: keyerror: "no data available" になる
- 1試合はやってるけどまだ振り分けられてない: final_rank_patchedが"unrated" になる。

みたいな感じっぽいのでそれっぽくやった。