### PR TITLE
noqa & act 1 handling

### DIFF
--- a/src/cogs/vl_rank_task.py
+++ b/src/cogs/vl_rank_task.py
@@ -100,9 +100,17 @@ class RankTasks(commands.Cog):
                     win_loses = "-W/-L"
                 else:
                     wins: int = current_season_data.get("wins", 0)
-                    number_of_games: int = current_season_data.get("number_of_games", 0)
-                    loses: int = number_of_games - wins
-                    win_loses = f"{wins}W/{loses}L"
+
+                    # アクト1は毎回5試合の振り分け戦があり、APIは上はその振り分け戦はwinをカウントせず、number_of_gamesだけがカウントされていく。
+                    # よってアクト1の場合のみ、number_of_gamesから5を引いた値 (振り分け戦が終わってから) W/Lをカウントすることにする。
+                    if current_season[-2:] == "a1":
+                        number_of_games: int = current_season_data.get("number_of_games", 0) - 5
+                        loses: int = number_of_games - wins
+                        win_loses = f"{wins}W/{loses}L"
+                    else:
+                        number_of_games: int = current_season_data.get("number_of_games", 0)
+                        loses: int = number_of_games - wins
+                        win_loses = f"{wins}W/{loses}L"
 
                 if win_loses == "-W/-L":
                     current_rank_info = "Unranked"
@@ -129,8 +137,7 @@ class RankTasks(commands.Cog):
                 )
 
                 # フォーマットに合わせて整形
-                result_string = f"{emoji} `{name} #{tag}` {rank_emoji}\n- {current_rank_info}\n- 前日比:\
-                  {plusminus}{todays_elo}\n- {win_loses}\n\n"
+                result_string = f"{emoji} `{name} #{tag}` {rank_emoji}\n- {current_rank_info}\n- 前日比: {plusminus}{todays_elo}\n- {win_loses}\n\n"  # noqa: E501
 
                 # DBの情報を今日の取得内容で更新
                 cur.execute(
@@ -150,7 +157,7 @@ class RankTasks(commands.Cog):
             join = await main()
 
             embed = discord.Embed()
-            embed.set_footer(text=season_txt)
+            embed.set_footer(text=f"{season_txt}\n※アクト1は振り分け戦の5試合分のW/Lをカウントしません。")
             embed.color = discord.Color.purple()
             embed.title = "みんなの昨日の活動です。"
             embed.description = f"{join}"

--- a/src/cogs/vl_rank_task.py
+++ b/src/cogs/vl_rank_task.py
@@ -101,8 +101,12 @@ class RankTasks(commands.Cog):
                 else:
                     wins: int = current_season_data.get("wins", 0)
 
-                    # アクト1は毎回5試合の振り分け戦があり、APIは上はその振り分け戦はwinをカウントせず、number_of_gamesだけがカウントされていく。
-                    # よってアクト1の場合のみ、number_of_gamesから5を引いた値 (振り分け戦が終わってから) W/Lをカウントすることにする。
+                    """
+                    アクト1は毎回5試合の振り分け戦があり、APIは上はその振り分け戦はwinをカウントせず、
+                    number_of_gamesだけがカウントされていく。
+                    よってアクト1の場合のみ、number_of_gamesから5を引いた値
+                    (振り分け戦が終わってから) W/Lをカウントすることにする。
+                    """
                     if current_season[-2:] == "a1":
                         number_of_games: int = current_season_data.get("number_of_games", 0) - 5
                         loses: int = number_of_games - wins


### PR DESCRIPTION
## noqa: E501のコメントを追加

- DiscordのEmbedの仕様への対応のため。

## アクト1のみW/Lの計算を変更

- Valorantには各Episodeでアクト1~3まである。
- エピソード最初のアクト1のみ、スタートの5試合は振り分け戦となっており、ランクが付いていない状態になる。
- 振り分け戦が終わるとはじめてランクがつく。
- 振り分け戦の戦績はAPIでは試合数のみ返してきて、勝数は返してこないことがわかった。
- なのでAct 1の場合のみ、振り分け戦の5試合分のW/Lはカウントしないことにした。