### PR TITLE
Railway移行に向けて /data, /logs ディレクトリを事前作成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,7 @@ COPY src/ ./src/
 
 RUN uv sync --frozen
 
+RUN mkdir -p /data /logs
+
 ENTRYPOINT ["uv", "run", "python", "src/main.py"]
 CMD []


### PR DESCRIPTION
## Summary
- docker-composeではホスト側のボリュームマウント(`./logs/:/logs/`)により`/logs`が自動作成されていたが、Railway環境ではこの仕組みがないため`TimedRotatingFileHandler`初期化時に`FileNotFoundError`が発生していた
- Dockerfile側で`/data`, `/logs`を明示的に作成するよう修正

## Test plan
- [x] `docker build` でローカルビルド成功
- [ ] Railway上でのデプロイ成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)