### PR TITLE
fix: Railwayでログが見えるように標準出力へも出力する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM python:3.12-slim-bookworm
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
+# Railwayのようにコンテナのstdout/stderrをログとして収集する環境で
+# print/loggingの出力がバッファに溜まって見えなくなるのを防ぐ
+ENV PYTHONUNBUFFERED=1
+
 # ローカルマシン(日本) のときは効果あるかも
 # RUN sed -i 's@archive.ubuntu.com@ftp.jaist.ac.jp/pub/Linux@g' /etc/apt/sources.list
 #一旦play.pyの導入は見送るのでとりあえずffmpegはコメントアウト

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,8 @@ logging.basicConfig(
             when="D",
             interval=1,
             backupCount=7,
-        )
+        ),
+        logging.StreamHandler(),
     ],
 )
 


### PR DESCRIPTION
## Summary
- `PYTHONUNBUFFERED=1` を設定し、stdoutのバッファリングによりログが遅延/欠落する問題を解消
- `logging.StreamHandler()` を追加し、ファイルだけでなく標準出力にもログを出力

Railwayはコンテナのstdout/stderrを集めてログとして表示する仕組みのため、これが無いと`railway logs`で運用状況を確認できなかった。

## Test plan
- [x] `docker build` でローカルビルド成功
- [ ] Railway上でデプロイし、`railway logs`にconnected!等の出力が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)