### PR TITLE
2代目に譲っていたautodelete/wt_taskを再有効化

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -73,12 +73,12 @@ class MyBot(commands.Bot):
 
         # コマンド系じゃないdevで読み込むと競合してややこしいcogs
         self.initial_extensions_only_production = [
-            # "cogs.autodelete",
+            "cogs.autodelete",
             "cogs.card_count",
             "cogs.save_image",
             "cogs.vc_role",
             "cogs.vcwhite",
-            # "cogs.wt_task",
+            "cogs.wt_task",
             "cogs.vl_rank_task",
         ]
 


### PR DESCRIPTION
## Summary
- Rust版(2代目)への移植のためコメントアウトしていた `cogs.autodelete`（10分毎のメッセージ削除）と `cogs.wt_task`（朝7時の挨拶・天気・雑学・株価投稿）を再有効化
- 2代目をRailwayから段階的に廃止し、初代に機能を一本化する方針のため
- 2代目側の `DeleteMessageTask` / `DailyMorningTask` は別途無効化し、重複投稿・重複削除を防ぐ

## Test plan
- [x] `docker build` でローカルビルド成功
- [ ] Railway上でデプロイし、10分後にメッセージ削除が実行されることを確認
- [ ] 翌朝7時の投稿が初代からのみ行われることを確認（2代目側の無効化とセットで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)