### PR TITLE
wt_task/geminiをRust版(2代目)の実装に揃える

### DIFF
--- a/src/cogs/gemini.py
+++ b/src/cogs/gemini.py
@@ -9,6 +9,7 @@ from libs.http_client import HTTPClient, handle_api_error
 from settings import GUILD_ID
 
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+GEMINI_MODEL = "gemini-2.5-flash"
 
 
 class Gemini(commands.Cog):
@@ -27,7 +28,7 @@ class Gemini(commands.Cog):
 
         await interaction.response.defer()
 
-        url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key={GEMINI_API_KEY}"
+        url = f"https://generativelanguage.googleapis.com/v1beta/models/{GEMINI_MODEL}:generateContent?key={GEMINI_API_KEY}"
         headers = {"Content-Type": "application/json"}
         payload = {"contents": [{"parts": [{"text": character}, {"text": key}]}]}
 
@@ -46,7 +47,7 @@ class Gemini(commands.Cog):
             title=f"Q. {key}",
             description=answer,
             color=discord.Color.dark_green(),
-            footer_text=f" Model: gemini-2.5-pro-exp-03-25\n🪀 キャラ設定: {character}",
+            footer_text=f" Model: {GEMINI_MODEL}\n🪀 キャラ設定: {character}",
         )
 
         await interaction.followup.send(embed=embed)

--- a/src/cogs/wt_task.py
+++ b/src/cogs/wt_task.py
@@ -57,41 +57,32 @@ class WTTasks(commands.Cog):
                 ("9023.T", "東京地下鉄", "円", ":metro:"),
             ]
 
-            stock_results = {}
-            # 各銘柄のデータを取得（リクエスト間に遅延を入れる）
+            # 市場データのテキスト生成（リクエスト間に遅延を入れる）
+            market_lines = []
             for ticker, name, unit, icon in market_data:
                 try:
                     day_before_ratio, stock_today = get_stock_price(ticker)
-                    stock_results[ticker] = (day_before_ratio, stock_today, name, unit, icon)
+                    market_lines.append(
+                        f"- {icon} **{name}:** {round(stock_today, 1):,}{unit} ({day_before_ratio})"
+                    )
                     # APIリクエスト制限回避のために遅延を入れる
                     time.sleep(0.5)
                 except YFRateLimitError:
                     print(f"Rate limit exceeded for ticker: {ticker}")
+                    market_lines.append(f"- {icon} **{name}:** データ取得失敗")
                     continue
                 except Exception as e:
                     print(f"Failed to get stock price for ticker: {ticker}")
                     print("Error message:", e)
+                    market_lines.append(f"- {icon} **{name}:** データ取得失敗")
                     continue
-
-            # 市場データのテキスト生成
-            market_lines = []
-            for ticker, (
-                day_before_ratio,
-                stock_today,
-                name,
-                unit,
-                icon,
-            ) in stock_results.items():
-                market_lines.append(
-                    f"- {icon} **{name}:** {round(stock_today, 1):,}{unit} ({day_before_ratio})"
-                )
 
             market_text = "\n".join(market_lines) + "\n※()内は前日比。"
 
             embed = discord.Embed()
-            embed.color = discord.Color.green()
+            embed.color = discord.Color(0x00FF00)
             embed.title = f"{good_morning}{this_month}月{this_day}日 朝の7時です。"
-            embed.description = f"### 💡 今日はなんの日？\n{result}\n### 📚 今日の雑学\n{trivia}(Powered by [gemini-2.5-pro-preview-05-06](https://ai.google.dev/gemini-api/docs/models))\n### 💹 相場\n{market_text}\n### ⛅ 今日の天気\n{tokyo_weather}\n{yamagata_weather}"  # noqa: E501
+            embed.description = f"### 💡 今日はなんの日？\n{result}\n\n### 📚 今日の雑学\n{trivia}\n(Powered by [Gemini](https://ai.google.dev/gemini-api/docs/models))\n\n### 💹 相場\n{market_text}\n\n### ⛅ 今日の天気\n{tokyo_weather}\n{yamagata_weather}"  # noqa: E501
             await channel.send(embed=embed)
 
     # デプロイ後Botが完全に起動してからタスクを回す

--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -96,7 +96,7 @@ def get_exchange_rate():
 
 async def get_trivia() -> str:
     """Gemini APIを使用して雑学を取得する。"""
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key={GEMINI_API_KEY}"
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={GEMINI_API_KEY}"
     headers = {"Content-Type": "application/json"}
     payload = {
         "contents": [


### PR DESCRIPTION
## Summary
2代目(nidaime-takohachi)への移植時に生まれていた実装差分を解消する。

- 雑学取得(`get_trivia`)のGeminiモデルを `gemini-2.5-pro` から `gemini-2.5-flash` に変更
- `/gemini` コマンドも同様にモデルをflashへ統一。footerの表示も実際に使用するモデル名を動的に参照するよう修正（旧表記 `gemini-2.5-pro-exp-03-25` は実際の呼び出しモデルとも不一致だった）
- 株価取得失敗時、該当銘柄の行を省略せず「データ取得失敗」と明示的に表示するよう変更（Rust版と同じ挙動）
- embedのdescriptionの見出し間に空行を追加し、Powered by表記を雑学本文と別行に分離（Rust版と同じレイアウト）
- embedの色を`discord.Color.green()`から`0x00FF00`の直接指定に変更（Rust版の`0x00ff00`と統一）

## Test plan
- [x] `docker build` でローカルビルド成功
- [ ] CI (ruff) の通過確認
- [ ] 翌朝7時の投稿でレイアウト・雑学モデルが2代目相当になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)