### PR TITLE
毎日朝4時にプロセスを自己終了しRailwayに再起動させる

### DIFF
--- a/src/cogs/daily_restart.py
+++ b/src/cogs/daily_restart.py
@@ -1,0 +1,38 @@
+import logging
+import sys
+from datetime import datetime, timedelta, timezone
+
+from discord.ext import commands, tasks
+
+RESTART_HOUR = 4
+
+
+class DailyRestart(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.checker.start()
+
+    def cog_unload(self):
+        self.checker.cancel()
+
+    @tasks.loop(seconds=60.0)
+    async def checker(self):
+        JST = timezone(timedelta(hours=+9), "JST")
+        now = datetime.now(JST)
+
+        if now.hour == RESTART_HOUR and now.minute == 0:
+            logging.info(
+                f"Scheduled daily restart triggered at {now.isoformat()}. Exiting process."
+            )
+            await self.bot.close()
+            # Railwayのrestart policy(ON_FAILURE)によって自動的に再起動されるよう、
+            # 意図的に非ゼロの終了コードでプロセスを終了する。
+            sys.exit(1)
+
+    @checker.before_loop
+    async def before_checker(self):
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(DailyRestart(bot))

--- a/src/main.py
+++ b/src/main.py
@@ -75,6 +75,7 @@ class MyBot(commands.Bot):
         self.initial_extensions_only_production = [
             "cogs.autodelete",
             "cogs.card_count",
+            "cogs.daily_restart",
             "cogs.save_image",
             "cogs.vc_role",
             "cogs.vcwhite",


### PR DESCRIPTION
## Summary
長時間稼働によるメモリリークや接続不安定化への対策として、毎日4:00 JSTにプロセスを意図的に終了させ、Railwayのrestart policy (ON_FAILURE, maxRetries: 10) によって自動的に再起動させる。

- 60秒ごとに現在時刻をチェックし、4:00になったら `bot.close()` → `sys.exit(1)`
- Railwayのrestart policyは非ゼロ終了コードの場合のみ再起動する挙動のため、意図的に異常終了させている
- 本番環境専用cog (`initial_extensions_only_production`) として追加

## Test plan
- [x] `docker build` でローカルビルド成功
- [ ] CIのlint通過確認
- [ ] 翌日4:00頃にRailway側でプロセスが再起動されることをログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)