### PR TITLE
get_stock_priceにリトライを追加(YFRateLimitError対策)

### DIFF
--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -7,6 +7,8 @@ from urllib import parse
 
 import httpx
 import yfinance as yf
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+from yfinance.exceptions import YFRateLimitError
 
 from libs.http_client import HTTPClient, APIError
 
@@ -134,6 +136,12 @@ async def get_trivia() -> str:
         return "⚠GeminiのAPIリクエストでエラーが発生したので今日の雑学はなしです。"
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    retry=retry_if_exception_type(YFRateLimitError),
+    wait=wait_exponential(multiplier=1, min=1, max=8),
+    reraise=True,
+)
 def get_stock_price(ticker_symbol: str):
     index = yf.Ticker(ticker_symbol)
 


### PR DESCRIPTION
## Summary
朝の投稿で日経225(^N225)のみ「データ取得失敗」になる事象が発生。個別に取得を試すと正常に取得できたため、恒常的な失敗ではなく一時的なレート制限(`YFRateLimitError`)の可能性が高いと判断。

`market_data`内で`USDJPY=X`の直後に`^N225`を取得しており、間の待機(`time.sleep(0.5)`)は成功時のみ挿入される実装のため、連続アクセスでレート制限にひっかかりやすい構造になっていた。

`tenacity`で最大3回・指数バックオフ(1〜8秒)のリトライを`get_stock_price`に追加し、一時的なレート制限であれば自動的に回復するようにした。`YFRateLimitError`以外の例外(データ不足など)は従来通り即座に呼び出し元へ伝播する。

## Test plan
- [x] `docker build` でローカルビルド成功
- [x] 全6銘柄(USD/JPY, 日経225, S&P500, NASDAQ, 丸千代山岡家, 東京地下鉄)で正常取得を確認
- [x] ruffのlint通過確認
- [ ] 翌朝の投稿で日経225が正常表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)