### PR TITLE
PRクローズ時にRailway PR環境由来のGitHub Deploymentsを自動削除する

### DIFF
--- a/.github/workflows/cleanup-pr-environment.yml
+++ b/.github/workflows/cleanup-pr-environment.yml
@@ -1,0 +1,27 @@
+name: Cleanup PR environment records
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+    steps:
+      - name: Delete GitHub deployments and environment for this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ENV_NAME: takohachi / takohachi-pr-${{ github.event.pull_request.number }}
+        run: |
+          set -e
+
+          ids=$(gh api "repos/${REPO}/deployments" --paginate --jq ".[] | select(.environment == \"${ENV_NAME}\") | .id")
+
+          for id in $ids; do
+            echo "Deactivating and deleting deployment $id"
+            gh api "repos/${REPO}/deployments/${id}/statuses" -f state=inactive >/dev/null
+            gh api -X DELETE "repos/${REPO}/deployments/${id}"
+          done


### PR DESCRIPTION
## 目的
Railway PR Environments はPRクローズ時にRailway側のインフラを自動削除するが、GitHub側のDeploymentsレコード（Environmentsタブに表示される）は残り続け、蓄積していく。

## 変更内容
`.github/workflows/cleanup-pr-environment.yml` を追加。PRクローズ(マージ含む)をトリガーに、`takohachi / takohachi-pr-{PR番号}` という environment 名を持つ deployment を検索し、inactive化した上で削除する。

## 確認したいこと
このPR自体をクローズしたときに、対応する `takohachi / takohachi-pr-<このPRの番号>` の deployment が実際に削除されるか。